### PR TITLE
reload game images on game path change

### DIFF
--- a/FocusTreeManager/AsyncImageLoader/AsyncImageLoader.cs
+++ b/FocusTreeManager/AsyncImageLoader/AsyncImageLoader.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using System.ComponentModel;
 using System.Windows.Media;
 using FocusTreeManager.Helper;
@@ -11,6 +12,8 @@ namespace FocusTreeManager.AsyncImageLoader
 
         private readonly BackgroundWorker ModWorker;
 
+        private bool restartStarterWorker;
+
         private static readonly object myLock = new object();
 
         private static AsyncImageLoader backWorkerSingleton = new AsyncImageLoader();
@@ -22,9 +25,20 @@ namespace FocusTreeManager.AsyncImageLoader
         private AsyncImageLoader()
         {
             StarterWorker = new BackgroundWorker();
+            StarterWorker.WorkerSupportsCancellation = true;
             StarterWorker.DoWork += StarterWorker_DoWork;
+            StarterWorker.RunWorkerCompleted += StarterWorker_RunWorkerCompleted;
             ModWorker = new BackgroundWorker();
             ModWorker.DoWork += ModWorker_DoWork;
+        }
+
+        private void StarterWorker_RunWorkerCompleted(object sender, RunWorkerCompletedEventArgs runWorkerCompletedEventArgs)
+        {
+            if (restartStarterWorker)
+            {
+                restartStarterWorker = false;
+                StartTheJob();
+            }
         }
 
         private void StarterWorker_DoWork(object sender, DoWorkEventArgs e)
@@ -35,7 +49,7 @@ namespace FocusTreeManager.AsyncImageLoader
 
         private void ModWorker_DoWork(object sender, DoWorkEventArgs e)
         {
-            foreach (KeyValuePair<string, ImageSource> images 
+            foreach (KeyValuePair<string, ImageSource> images
                 in ImageHelper.RefreshFromMods(ImageType.Goal))
             {
                 Focuses[images.Key] = images.Value;
@@ -45,6 +59,18 @@ namespace FocusTreeManager.AsyncImageLoader
             {
                 Events[images.Key] = images.Value;
             }
+        }
+
+        public void RestartStarterWorker()
+        {
+            if (!StarterWorker.IsBusy)
+            {
+                StartTheJob();
+                return;
+            }
+
+            restartStarterWorker = true;
+            StarterWorker.CancelAsync();
         }
 
         public void StartTheJob()

--- a/FocusTreeManager/ViewModel/SettingsViewModel.cs
+++ b/FocusTreeManager/ViewModel/SettingsViewModel.cs
@@ -47,6 +47,7 @@ namespace FocusTreeManager.ViewModel
             {
                 Configurator.setGamePath(value);
                 RaisePropertyChanged(() => GamePath);
+                AsyncImageLoader.AsyncImageLoader.Worker.RestartStarterWorker();
             }
         }
 
@@ -73,7 +74,7 @@ namespace FocusTreeManager.ViewModel
         public SettingsViewModel()
         {
             AvailableLanguages = Configurator.returnAllLanguages();
-            selectedLanguage = AvailableLanguages.SingleOrDefault(l => l.FileName == 
+            selectedLanguage = AvailableLanguages.SingleOrDefault(l => l.FileName ==
                 Configurator.getLanguage());
             FindCommand = new RelayCommand(SelectGameFolder);
             if (!Configurator.getFirstStart())


### PR DESCRIPTION
So, game image loading happens only inside the App constructor. Meaning the first time you run the program the images never get loaded because the game path isn't set, and there is nothing to set image loading in motion after you set the path.